### PR TITLE
Feature/use form hook

### DIFF
--- a/__tests__/components/Auth.test.js
+++ b/__tests__/components/Auth.test.js
@@ -31,7 +31,7 @@ test('Shows an error message if the email address is invalid', async () => {
   userEvent.type(input, 'notanemail')
   fireEvent.submit(form)
 
-  await screen.findByText(/email is not valid/i)
+  await screen.findByText(/email address is invalid/i)
 })
 
 test('Shows an error message if the password is invalid', async () => {

--- a/components/Auth.js
+++ b/components/Auth.js
@@ -11,16 +11,29 @@ import {
   Link,
   VStack,
 } from '@chakra-ui/react'
+import { useForm } from '../lib/forms/useForm'
 
 const Auth = ({ heading }) => {
-  const [email, setEmail] = useState('')
-  const [emailIsError, setEmailIsError] = useState(false)
-  const [emailErrorMessage, setEmailErrorMessage] = useState('')
-  const [password, setPassword] = useState('')
-  const [passwordIsError, setPasswordIsError] = useState(false)
-  const [passwordErrorMessage, setPasswordErrorMessage] = useState('')
   const [successMessage, setSuccessMessage] = useState('')
   const { signIn, loading } = useAuth()
+
+  const formFields = {
+    email: {
+      value: '',
+      isRequired: true,
+      pattern: /[^@ \t\r\n]+@[^@ \t\r\n]+\.[^@ \t\r\n]+/,
+      errorMessage: 'Email address is invalid',
+    },
+    password: {
+      value: '',
+      isRequired: true,
+      pattern:
+        /^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$ %^&*-]).{6,}$/, //  Minimum six characters, at least one upper case English letter, one lower case English letter, one number and one special character.
+      errorMessage:
+        'Password must be at least six characters; contain one uppercase letter, one number and one special character',
+    },
+  }
+  const { fields, handleChange, validateFields, error } = useForm(formFields)
 
   useEffect(() => {
     if (heading === 'Sign in') {
@@ -32,47 +45,15 @@ const Auth = ({ heading }) => {
     }
   }, [heading])
 
-  const validateEmail = (email) => {
-    const emailRegex = /[^@ \t\r\n]+@[^@ \t\r\n]+\.[^@ \t\r\n]+/
-
-    if (email.length === 0) {
-      setEmailIsError(true)
-      setEmailErrorMessage('Email is required')
-    } else if (emailRegex.test(email) === false) {
-      setEmailIsError(true)
-      setEmailErrorMessage('Email is not valid')
-    } else {
-      setEmailIsError(false)
-    }
-  }
-
-  const validatePassword = (password) => {
-    //  Minimum six characters, at least one upper case English letter, one lower case English letter, one number and one special character.
-    const pwRegex =
-      /^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$ %^&*-]).{6,}$/
-
-    if (password.length === 0) {
-      setPasswordIsError(true)
-      setPasswordErrorMessage('Password is required')
-    } else if (pwRegex.test(password) === false) {
-      setPasswordIsError(true)
-      setPasswordErrorMessage(
-        'Password must be at least six characters; contain one uppercase letter, one number and one special character',
-      )
-    } else {
-      setPasswordIsError(false)
-    }
-  }
-
   const handleLogin = async (e) => {
+    const email = fields.email.value
+    const password = fields.password.value
+
     e.preventDefault()
 
-    validateEmail(email)
-    validatePassword(password)
+    const { isValid } = validateFields()
 
-    if (emailIsError === false && passwordIsError == false) {
-      await signIn({ email, password, successMessage })
-    }
+    isValid ? await signIn({ email, password, successMessage }) : null
   }
 
   return (
@@ -81,7 +62,10 @@ const Auth = ({ heading }) => {
 
       <form onSubmit={(e) => handleLogin(e)} name="signInForm" noValidate>
         <VStack align="stretch">
-          <FormControl isRequired isInvalid={emailIsError}>
+          <FormControl
+            isRequired={formFields.email.isRequired}
+            isInvalid={error.email}
+          >
             <FormLabel htmlFor="email" data-testid="label">
               Your email
             </FormLabel>
@@ -89,28 +73,31 @@ const Auth = ({ heading }) => {
               id="email"
               type="email"
               name="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
+              value={fields.email.value}
+              onChange={handleChange}
             />
 
-            {emailIsError ? (
-              <FormErrorMessage>{emailErrorMessage}</FormErrorMessage>
+            {error.email ? (
+              <FormErrorMessage>{error.email}</FormErrorMessage>
             ) : null}
           </FormControl>
 
-          <FormControl isRequired isInvalid={passwordIsError}>
+          <FormControl
+            isRequired={formFields.password.isRequired}
+            isInvalid={error.password}
+          >
             <FormLabel htmlFor="password">Password</FormLabel>
 
             <Input
               id="password"
               type="password"
               name="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
+              value={fields.password.value}
+              onChange={handleChange}
             />
 
-            {passwordIsError ? (
-              <FormErrorMessage>{passwordErrorMessage}</FormErrorMessage>
+            {error.password ? (
+              <FormErrorMessage>{error.password}</FormErrorMessage>
             ) : null}
           </FormControl>
 

--- a/lib/forms/useForm.js
+++ b/lib/forms/useForm.js
@@ -1,0 +1,70 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * Custom useForm hook
+ *
+ * @param {object} initialState object of the form fields with properties
+ *  e.g. {email: {
+      value: '',
+      isRequired: true,
+      pattern: /[^@ \t\r\n]+@[^@ \t\r\n]+\.[^@ \t\r\n]+/,
+      errorMessage: 'Email address is invalid',
+    },}
+ * @returns {object} fields, handleChange, validateFields, error
+ */
+const useForm = (initialState = {}) => {
+  const [fields, setFields] = useState(initialState)
+  const [error, setError] = useState({})
+
+  /**
+   * Handle the change of the value in our form fields so they update in here
+   *
+   * @param {event} e
+   */
+  const handleChange = (e) => {
+    const fieldValues = {
+      ...fields,
+      [e.target.name]: { ...fields[e.target.name], value: e.target.value },
+    }
+
+    setFields(fieldValues)
+  }
+
+  /**
+   * Checks whether value is greater than 0 or empty
+   *
+   * @param {string} value
+   * @returns {boolean} Boolean
+   */
+  const hasValue = (value) => value != null && value.trim().length > 0
+
+  /**
+   * Loops over the form fields object and validate each field value.
+   * If a field is invalis set the formValid state to false.
+   *
+   * @returns {object} err, isValid
+   */
+  const validateFields = () => {
+    let err = {}
+    let isValid = false
+
+    for (const field in fields) {
+      if (hasValue(fields[field].value) === false) {
+        err = { ...err, [field]: `${field} is required` }
+      } else if (fields[field].pattern.test(fields[field].value) === false) {
+        err = { ...err, [field]: fields[field]?.errorMessage }
+      } else {
+        err = { ...err, [field]: '' }
+        isValid = true
+      }
+    }
+
+    setError(err)
+
+    return { err, isValid }
+  }
+
+  return { fields, handleChange, validateFields, error }
+}
+
+export { useForm }


### PR DESCRIPTION
Adds a custom hook for managing form validation and state.

This separates the form validation that was within the `<Auth/>` component so we can re-use it across other forms. For example the Profile form (this will be refactored to use this in another PR).